### PR TITLE
Fix: Fix length and width ratios bug

### DIFF
--- a/utils/bbox.py
+++ b/utils/bbox.py
@@ -148,7 +148,7 @@ def post_process(prediction, num_classes, input_shape, image_info, conf_thres=0.
             box_yx = box_xy[..., ::-1]
             box_hw = box_wh[..., ::-1]
             input_shape = np.array(input_shape)
-            image_shape = np.array([image_info[i][1], image_info[i][2]])
+            image_shape = np.array([image_info[i][2], image_info[i][1]])
 
             box_mins = box_yx - (box_hw / 2.)
             box_maxes = box_yx + (box_hw / 2.)


### PR DESCRIPTION
Fix a serious bug that may affect the accuracy of images with different length and width ratios, but not when the length and width ratio is the same. The reason is that the code input length and width ratio is wrong, severe impact evaluation and inference.